### PR TITLE
Override model.fetch as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,13 @@ module.exports = function (Bookshelf) {
       return mProto.fetch.apply(this, arguments);
     },
 
+    fetchAll: function (opts) {
+      if (this.soft && !shouldDisable(opts)) {
+        addDeletionCheck(this);
+      }
+      return mProto.fetchAll.apply(this, arguments);
+    },
+
     restore: function () {
       if (this.soft) {
         if (this.get('deleted_at')) {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,10 @@ module.exports = function (Bookshelf) {
 
   Bookshelf.Collection = Bookshelf.Collection.extend({
     fetch: function (opts) {
-      if (this.model.soft && !shouldDisable(opts)) {
+      /*eslint-disable new-cap*/
+      var isSoft = (new this.model()).soft;
+      /*eslint-enable new-cap*/
+      if (isSoft && !shouldDisable(opts)) {
         addDeletionCheck(this);
       }
       return cProto.fetch.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/lanetix/node-bookshelf-soft-delete",
   "dependencies": {
-    "lazy.js": "^0.4.0",
     "bluebird": "^2.3.11"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,36 @@ describe('bookshelf soft delete', function () {
         });
     });
 
+    it('should not be visibile in model fetch', function () {
+      return Model
+        .forge({ id: 1 })
+        .fetch()
+        .then(function (model) {
+          should.not.exist(model);
+        });
+    });
+
+    xit('should not be visibile in model fetchAll', function () {
+    });
+
+    it(
+      'should be visibile in model fetch with softDelete: false',
+      function () {
+        return Model
+          .forge({ id: 1 })
+          .fetch({ softDelete: false })
+          .then(function (model) {
+            should.exist(model);
+          });
+      }
+    );
+
+    xit(
+      'should be visibile in model fetchAll with softDelete: false',
+      function () {
+      }
+    );
+
     it('should not be visible in fetches', function () {
       return (new Collection())
         .fetch()
@@ -63,7 +93,7 @@ describe('bookshelf soft delete', function () {
       before(function () {
         return Model
           .forge({ id: 1 })
-          .fetch()
+          .fetch({ softDelete: false })
           .then(function (model) {
             return model.restore();
           });

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ describe('bookshelf soft delete', function () {
           .forge()
           .fetchAll({ softDelete: false })
           .then(function (results) {
-            results.length.should.equal(0);
+            results.length.should.equal(1);
           });
       }
     );

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,13 @@ describe('bookshelf soft delete', function () {
         });
     });
 
-    xit('should not be visibile in model fetchAll', function () {
+    it('should not be visibile in model fetchAll', function () {
+      return Model
+        .forge()
+        .fetchAll()
+        .then(function (results) {
+          results.length.should.equal(0);
+        });
     });
 
     it(
@@ -51,9 +57,15 @@ describe('bookshelf soft delete', function () {
       }
     );
 
-    xit(
+    it(
       'should be visibile in model fetchAll with softDelete: false',
       function () {
+        return Model
+          .forge()
+          .fetchAll({ softDelete: false })
+          .then(function (results) {
+            results.length.should.equal(0);
+          });
       }
     );
 


### PR DESCRIPTION
This resolves #6 and overhauls the method for returning only things which haven't been soft deleted so that it acts as a sql query instead of mutating the results returned from the database. This approach has a few advantages which follow.

- results of a fetch now correctly report length
- `fetchOne` and `model.fetch` no longer return `null` if there is a thing which has been soft deleted returned first.
- `fetchOne` does not need its own override (bookshelf delegates to the model for this).