### PR TITLE
Add support for queries with joins

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,21 @@ function shouldDisable(opts) {
 }
 
 function addDeletionCheck(syncable) {
+  var deletedAtField = softFields[0];
+  var restoredAtField = softFields[1];
+
+  /*eslint-disable no-underscore-dangle*/
+  if (syncable._knex) {
+    var table = syncable._knex._single.table;
+    /*eslint-enable no-underscore-dangle*/
+
+    deletedAtField = table + '.' + softFields[0];
+    restoredAtField = table + '.' + softFields[1];
+  }
+
   syncable.query(function (qb) {
     qb.where(function () {
-      this.whereNull(softFields[0]).orWhereNotNull(softFields[1]);
+      this.whereNull(deletedAtField).orWhereNotNull(restoredAtField);
     });
   });
 }

--- a/migrations/20151102184234_soft-delete-queries.js
+++ b/migrations/20151102184234_soft-delete-queries.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function (knex) {
+  return knex.schema.createTable('test3', function (t) {
+    t.increments('id').primary();
+    t.integer('model1').references('test.id');
+    t.integer('model2').references('test2.id');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable('test3');
+};

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,8 @@ var lib = require('./lib'),
   should = require('should'),
   BPromise = require('bluebird'),
   Model = lib.Model,
-  Model2 = lib.Model2;
+  Model2 = lib.Model2,
+  Model3 = lib.Model3;
 
 describe('bookshelf soft delete', function () {
   before(function () {
@@ -29,6 +30,10 @@ describe('bookshelf soft delete', function () {
           ids = models.map(function (model) {
             return model.id;
           });
+
+          return Model3
+            .forge({ model1: ids[1] })
+            .save();
         });
     });
 
@@ -40,6 +45,20 @@ describe('bookshelf soft delete', function () {
 
     it('should not affect model.fetch()', function () {
       return Model.forge({ id: ids[1] })
+        .fetch()
+        .then(function (model) {
+          should.exist(model);
+          model.id.should.equal(ids[1]);
+        });
+    });
+
+    it('should not affect model.fetch() after a join query', function () {
+      return Model
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': ids[1]
+          });
+        })
         .fetch()
         .then(function (model) {
           should.exist(model);
@@ -58,10 +77,15 @@ describe('bookshelf soft delete', function () {
         .then(function () {
           id = model.id;
           return model.destroy();
+        })
+        .then(function () {
+          return Model3
+            .forge({ model1: id })
+            .save();
         });
     });
 
-    it('should not be visibile in model fetch', function () {
+    it('should not be visible in model fetch', function () {
       return Model
         .forge({ id: id })
         .fetch()
@@ -70,7 +94,20 @@ describe('bookshelf soft delete', function () {
         });
     });
 
-    it('should not be visibile in model fetchAll', function () {
+    it('should not be visible in model fetch after a join query', function () {
+      return Model
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
+          });
+        })
+        .fetch()
+        .then(function (model) {
+          should.not.exist(model);
+        });
+    });
+
+    it('should not be visible in model fetchAll', function () {
       return Model
         .forge()
         .fetchAll()
@@ -79,32 +116,78 @@ describe('bookshelf soft delete', function () {
         });
     });
 
-    it(
-      'should be visibile in model fetch with softDelete: false',
-      function () {
-        return Model
-          .forge({ id: id })
-          .fetch({ softDelete: false })
-          .then(function (model) {
-            should.exist(model);
+    it('should not be visible in model fetchAll after a join query', function () {
+      return Model
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
           });
-      }
-    );
+        })
+        .fetchAll()
+        .then(function (results) {
+          results.length.should.equal(0);
+        });
+    });
 
-    it(
-      'should be visibile in model fetchAll with softDelete: false',
-      function () {
-        return Model
-          .forge()
-          .fetchAll({ softDelete: false })
-          .then(function (results) {
-            results.length.should.equal(1);
+    it('should be visible in model fetch with softDelete: false', function () {
+      return Model
+        .forge({ id: id })
+        .fetch({ softDelete: false })
+        .then(function (model) {
+          should.exist(model);
+        });
+    });
+
+    it('should be visible in model fetch after a join query with softDelete: false', function () {
+      return Model
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
           });
-      }
-    );
+        })
+        .fetch({ softDelete: false })
+        .then(function (model) {
+          should.exist(model);
+        });
+    });
+
+    it('should be visible in model fetchAll with softDelete: false', function () {
+      return Model
+        .forge()
+        .fetchAll({ softDelete: false })
+        .then(function (results) {
+          results.length.should.equal(1);
+        });
+    });
+
+    it('should be visible in model fetchAll after a join query with softDelete: false', function () {
+      return Model
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
+          });
+        })
+        .fetchAll({ softDelete: false })
+        .then(function (results) {
+          results.length.should.equal(1);
+        });
+    });
 
     it('should not be visible in fetches', function () {
       return (new Collection())
+        .fetch()
+        .then(function (results) {
+          results.models.length.should.equal(0);
+        });
+    });
+
+    it('should not be visible in fetches after a join query', function () {
+      return (new Collection())
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
+          });
+        })
         .fetch()
         .then(function (results) {
           results.models.length.should.equal(0);
@@ -119,7 +202,20 @@ describe('bookshelf soft delete', function () {
         });
     });
 
-    it('should be be visible in softDelete: false fetchOne', function () {
+    it('should not be visible in fetchOne after a join query', function () {
+      return (new Collection())
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
+          });
+        })
+        .fetchOne()
+        .then(function (result) {
+          should.not.exist(result);
+        });
+    });
+
+    it('should be visible in fetchOne with softDelete: false', function () {
       return (new Collection())
         .fetchOne({ softDelete: false })
         .then(function (result) {
@@ -127,8 +223,34 @@ describe('bookshelf soft delete', function () {
         });
     });
 
-    it('should be be visible in softDelete: false fetches', function () {
+    it('should be visible in fetchOne after a join query with softDelete: false', function () {
       return (new Collection())
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
+          });
+        })
+        .fetchOne({ softDelete: false })
+        .then(function (result) {
+          should.exist(result);
+        });
+    });
+
+    it('should be visible in fetches with softDelete: false', function () {
+      return (new Collection())
+        .fetch({ softDelete: false })
+        .then(function (results) {
+          results.models.length.should.equal(1);
+        });
+    });
+
+    it('should be visible in fetches after a join query with softDelete: false', function () {
+      return (new Collection())
+        .query(function (qb) {
+          qb.join('test3', 'test.id', 'test3.model1').where({
+            'test3.model1': id
+          });
+        })
         .fetch({ softDelete: false })
         .then(function (results) {
           results.models.length.should.equal(1);
@@ -153,6 +275,19 @@ describe('bookshelf soft delete', function () {
           });
       });
 
+      it('should be visible in fetches after a join query', function () {
+        return (new Collection())
+          .query(function (qb) {
+            qb.join('test3', 'test.id', 'test3.model1').where({
+              'test3.model1': id
+            });
+          })
+          .fetch()
+          .then(function (results) {
+            results.models.length.should.equal(1);
+          });
+      });
+
       it('should be visible in fetchOne', function () {
         return (new Collection())
           .fetchOne()
@@ -161,11 +296,23 @@ describe('bookshelf soft delete', function () {
           });
       });
 
+      it('should be visible in fetchOne after a join query', function () {
+        return (new Collection())
+          .query(function (qb) {
+            qb.join('test3', 'test.id', 'test3.model1').where({
+              'test3.model1': id
+            });
+          })
+          .fetchOne()
+          .then(function (result) {
+            should.exist(result);
+          });
+      });
     });
   });
 });
-describe('bookshelf soft delete with named fields', function () {
 
+describe('bookshelf soft delete with named fields', function () {
   after(function () {
     fs.unlinkSync(path.join(__dirname, '../dev.sqlite3'));
   });
@@ -183,6 +330,10 @@ describe('bookshelf soft delete with named fields', function () {
           ids = models.map(function (model) {
             return model.id;
           });
+
+          return Model3
+            .forge({ model2: ids[1] })
+            .save();
         });
     });
 
@@ -194,6 +345,20 @@ describe('bookshelf soft delete with named fields', function () {
 
     it('should not affect model.fetch()', function () {
       return Model2.forge({ id: ids[1] })
+        .fetch()
+        .then(function (model) {
+          should.exist(model);
+          model.id.should.equal(ids[1]);
+        });
+    });
+
+    it('should not affect model.fetch() after a join query', function () {
+      return Model2
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': ids[1]
+          });
+        })
         .fetch()
         .then(function (model) {
           should.exist(model);
@@ -212,10 +377,15 @@ describe('bookshelf soft delete with named fields', function () {
         .then(function () {
           id = model.id;
           return model.destroy();
+        })
+        .then(function () {
+          return Model3
+            .forge({ model2: id })
+            .save();
         });
     });
 
-    it('should not be visibile in model fetch', function () {
+    it('should not be visible in model fetch', function () {
       return Model2
         .forge({ id: id })
         .fetch()
@@ -224,7 +394,20 @@ describe('bookshelf soft delete with named fields', function () {
         });
     });
 
-    it('should not be visibile in model fetchAll', function () {
+    it('should not be visible in model fetch after a join query', function () {
+      return Model2
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
+          });
+        })
+        .fetch()
+        .then(function (model) {
+          should.not.exist(model);
+        });
+    });
+
+    it('should not be visible in model fetchAll', function () {
       return Model2
         .forge()
         .fetchAll()
@@ -233,32 +416,78 @@ describe('bookshelf soft delete with named fields', function () {
         });
     });
 
-    it(
-      'should be visibile in model fetch with softDelete: false',
-      function () {
-        return Model2
-          .forge({ id: id })
-          .fetch({ softDelete: false })
-          .then(function (model) {
-            should.exist(model);
+    it('should not be visible in model fetchAll after a join query', function () {
+      return Model2
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
           });
-      }
-    );
+        })
+        .fetchAll()
+        .then(function (results) {
+          results.length.should.equal(0);
+        });
+    });
 
-    it(
-      'should be visibile in model fetchAll with softDelete: false',
-      function () {
-        return Model2
-          .forge()
-          .fetchAll({ softDelete: false })
-          .then(function (results) {
-            results.length.should.equal(1);
+    it('should be visible in model fetch with softDelete: false', function () {
+      return Model2
+        .forge({ id: id })
+        .fetch({ softDelete: false })
+        .then(function (model) {
+          should.exist(model);
+        });
+    });
+
+    it('should be visible in model fetch after a join query with softDelete: false', function () {
+      return Model2
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
           });
-      }
-    );
+        })
+        .fetch({ softDelete: false })
+        .then(function (model) {
+          should.exist(model);
+        });
+    });
+
+    it('should be visible in model fetchAll with softDelete: false', function () {
+      return Model2
+        .forge()
+        .fetchAll({ softDelete: false })
+        .then(function (results) {
+          results.length.should.equal(1);
+        });
+    });
+
+    it('should be visible in model fetchAll after a join query with softDelete: false', function () {
+      return Model2
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
+          });
+        })
+        .fetchAll({ softDelete: false })
+        .then(function (results) {
+          results.length.should.equal(1);
+        });
+    });
 
     it('should not be visible in fetches', function () {
       return (new Collection2())
+        .fetch()
+        .then(function (results) {
+          results.models.length.should.equal(0);
+        });
+    });
+
+    it('should not be visible in fetches after a join query', function () {
+      return (new Collection2())
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
+          });
+        })
         .fetch()
         .then(function (results) {
           results.models.length.should.equal(0);
@@ -273,7 +502,20 @@ describe('bookshelf soft delete with named fields', function () {
         });
     });
 
-    it('should be be visible in softDelete: false fetchOne', function () {
+    it('should not be visible in fetchOne after a join query', function () {
+      return (new Collection2())
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
+          });
+        })
+        .fetchOne()
+        .then(function (result) {
+          should.not.exist(result);
+        });
+    });
+
+    it('should be visible in fetchOne with softDelete: false', function () {
       return (new Collection2())
         .fetchOne({ softDelete: false })
         .then(function (result) {
@@ -281,8 +523,34 @@ describe('bookshelf soft delete with named fields', function () {
         });
     });
 
-    it('should be be visible in softDelete: false fetches', function () {
+    it('should be visible in fetchOne after a join query with softDelete: false', function () {
       return (new Collection2())
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
+          });
+        })
+        .fetchOne({ softDelete: false })
+        .then(function (result) {
+          should.exist(result);
+        });
+    });
+
+    it('should be visible in fetches with softDelete: false', function () {
+      return (new Collection2())
+        .fetch({ softDelete: false })
+        .then(function (results) {
+          results.models.length.should.equal(1);
+        });
+    });
+
+    it('should be visible in fetches after a join query with softDelete: false', function () {
+      return (new Collection2())
+        .query(function (qb) {
+          qb.join('test3', 'test2.id', 'test3.model2').where({
+            'test3.model2': id
+          });
+        })
         .fetch({ softDelete: false })
         .then(function (results) {
           results.models.length.should.equal(1);
@@ -307,6 +575,19 @@ describe('bookshelf soft delete with named fields', function () {
           });
       });
 
+      it('should be visible in fetches after a join query', function () {
+        return (new Collection2())
+          .query(function (qb) {
+            qb.join('test3', 'test2.id', 'test3.model2').where({
+              'test3.model2': id
+            });
+          })
+          .fetch()
+          .then(function (results) {
+            results.models.length.should.equal(1);
+          });
+      });
+
       it('should be visible in fetchOne', function () {
         return (new Collection2())
           .fetchOne()
@@ -315,6 +596,18 @@ describe('bookshelf soft delete with named fields', function () {
           });
       });
 
+      it('should be visible in fetchOne after a join query', function () {
+        return (new Collection2())
+          .query(function (qb) {
+            qb.join('test3', 'test2.id', 'test3.model2').where({
+              'test3.model2': id
+            });
+          })
+          .fetchOne()
+          .then(function (result) {
+            should.exist(result);
+          });
+      });
     });
   });
 });

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   Model: require('./model'),
   Model2: require('./model2'),
+  Model3: require('./model3'),
   Collection: require('./collection'),
   Collection2: require('./collection2')
 };

--- a/test/lib/model3.js
+++ b/test/lib/model3.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var repository = require('./repo');
+
+module.exports = repository.Model.extend({
+  tableName: 'test3'
+});


### PR DESCRIPTION
This PR closes #19. A condition is added to check if the model or collection contains the knex query builder, adding the table prefix to the soft delete attributes clauses.