### PR TITLE
Add support for count

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,16 @@ module.exports = function (Bookshelf) {
         addDeletionCheck(this);
       }
       return cProto.fetch.apply(this, arguments);
+    },
+
+    count: function (field, opts) {
+      opts = opts || field;
+
+      if (softActivated && !shouldDisable(opts)) {
+        addDeletionCheck(this);
+      }
+
+      return cProto.count.apply(this, arguments);
     }
   });
 };

--- a/migrations/20151109134124_soft-delete-count.js
+++ b/migrations/20151109134124_soft-delete-count.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function (knex) {
+  return knex.schema.createTable('test4', function (t) {
+    t.increments('id').primary();
+    t.datetime('restored_at').nullable();
+    t.datetime('deleted_at').nullable();
+    t.string('foo');
+    t.string('qux');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable('test4');
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bluebird": "^2.3.11"
   },
   "devDependencies": {
-    "bookshelf": "^0.7.9",
+    "bookshelf": "^0.9.1",
     "eslint": "^0.13.0",
     "eslint-plugin-nodeca": "^1.0.3",
     "knex": "^0.7.3",

--- a/test/lib/collection4.js
+++ b/test/lib/collection4.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var repo = require('./repo'),
+  model = require('./model4');
+
+module.exports = repo.Collection.extend({
+  model: model
+});

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -4,6 +4,8 @@ module.exports = {
   Model: require('./model'),
   Model2: require('./model2'),
   Model3: require('./model3'),
+  Model4: require('./model4'),
   Collection: require('./collection'),
-  Collection2: require('./collection2')
+  Collection2: require('./collection2'),
+  Collection4: require('./collection4')
 };

--- a/test/lib/model4.js
+++ b/test/lib/model4.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var repository = require('./repo');
+
+module.exports = repository.Model.extend({
+  tableName: 'test4'
+});


### PR DESCRIPTION
This PR adds support for `count`. The bookshelf version was updated since this feature is only available since 0.8.2. No tests were added to the `bookshelf soft delete with named fields` section since it seemed obsolete, although if you see it fit just say so and I'll add them.